### PR TITLE
Add --reference argument for cram decompression

### DIFF
--- a/src/extract_from_bam.rs
+++ b/src/extract_from_bam.rs
@@ -15,7 +15,7 @@ pub struct Data {
 pub fn extract(
     bam_path: &String,
     threads: usize,
-    reference: &String,
+    reference: Option<String>,
     min_read_len: usize,
     arrow: Option<String>,
     chroms: bool,
@@ -37,9 +37,12 @@ pub fn extract(
     };
     bam.set_threads(threads)
         .expect("Failure setting decompression threads");
-    if !reference.is_empty() {
-        bam.set_reference(reference)
-            .expect("Failure setting bam/cram reference");
+
+    match reference {
+        None => (),
+        Some(s) => bam
+            .set_reference(s)
+            .expect("Failure setting bam/cram reference"),
     }
     for read in bam
         .rc_records()

--- a/src/extract_from_bam.rs
+++ b/src/extract_from_bam.rs
@@ -15,6 +15,7 @@ pub struct Data {
 pub fn extract(
     bam_path: &String,
     threads: usize,
+    reference: &String,
     min_read_len: usize,
     arrow: Option<String>,
     chroms: bool,
@@ -36,6 +37,9 @@ pub fn extract(
     };
     bam.set_threads(threads)
         .expect("Failure setting decompression threads");
+    bam.set_reference(reference)
+        .expect("Failure setting bam/cram reference");
+
     for read in bam
         .rc_records()
         .map(|r| r.expect("Failure parsing Bam file"))

--- a/src/extract_from_bam.rs
+++ b/src/extract_from_bam.rs
@@ -37,9 +37,10 @@ pub fn extract(
     };
     bam.set_threads(threads)
         .expect("Failure setting decompression threads");
-    bam.set_reference(reference)
-        .expect("Failure setting bam/cram reference");
-
+    if !reference.is_empty() {
+        bam.set_reference(reference)
+            .expect("Failure setting bam/cram reference");
+    }
     for read in bam
         .rc_records()
         .map(|r| r.expect("Failure parsing Bam file"))

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ struct Cli {
     threads: usize,
 
     /// reference for decompressing bam/cram
-    #[clap(value_parser, validator=is_file, default_value = "")]
+    #[clap(long, default_value = "")]
     reference: String,
 
     /// Minimal length of read to be considered

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,10 @@ struct Cli {
     #[clap(short, long, value_parser, default_value_t = 4)]
     threads: usize,
 
+    /// reference for decompressing bam/cram
+    #[clap(value_parser, validator=is_file, default_value = "")]
+    reference: String,
+
     /// Minimal length of read to be considered
     #[clap(short, long, value_parser, default_value_t = 0)]
     min_read_len: usize,
@@ -72,6 +76,7 @@ fn main() {
     metrics_from_bam(
         args.input,
         args.threads,
+        args.reference,
         args.min_read_len,
         args.hist,
         args.checksum,
@@ -86,6 +91,7 @@ fn main() {
 fn metrics_from_bam(
     bam: String,
     threads: usize,
+    reference: String,
     min_read_len: usize,
     hist: bool,
     checksum: bool,
@@ -97,6 +103,7 @@ fn metrics_from_bam(
     let metrics = extract_from_bam::extract(
         &bam,
         threads,
+        &reference,
         min_read_len,
         arrow,
         karyotype,

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,8 +27,8 @@ struct Cli {
     threads: usize,
 
     /// reference for decompressing bam/cram
-    #[clap(long, default_value = "")]
-    reference: String,
+    #[clap(long, value_parser)]
+    reference: Option<String>,
 
     /// Minimal length of read to be considered
     #[clap(short, long, value_parser, default_value_t = 0)]
@@ -91,7 +91,7 @@ fn main() {
 fn metrics_from_bam(
     bam: String,
     threads: usize,
-    reference: String,
+    reference: Option<String>,
     min_read_len: usize,
     hist: bool,
     checksum: bool,
@@ -103,7 +103,7 @@ fn metrics_from_bam(
     let metrics = extract_from_bam::extract(
         &bam,
         threads,
-        &reference,
+        reference,
         min_read_len,
         arrow,
         karyotype,
@@ -192,6 +192,7 @@ fn extract() {
     metrics_from_bam(
         "test-data/small-test-phased.bam".to_string(),
         8,
+        None,
         0,
         true,
         true,


### PR DESCRIPTION
This was helpful for non-standard references or if there were any issues with firewalls like

```
[E::easy_errno] Libcurl reported error 60 (SSL peer certificate or SSH remote key was not OK)
[W::find_file_url] Failed to open reference "https://www.ebi.ac.uk/ena/cram/md5/9f1e20f56671ea323b75f6a3356048bb": Input/output error
```