### PR TITLE
Delete filtering contigs on `_` in `--karyotype`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,5 +30,3 @@ libz-sys = "1.1.12"
 [dev-dependencies]
 ctor = "0.2.4"
 
-[target.x86_64-apple-darwin]
-rustflags = ["-C", "link-arg=-mmacosx-version-min=10.12"]

--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,2 @@
+[target.x86_64-apple-darwin]
+rustflags = ["-C", "link-arg=-mmacosx-version-min=10.12"]

--- a/src/karyotype.rs
+++ b/src/karyotype.rs
@@ -14,11 +14,9 @@ pub fn make_karyotype(tids: &Vec<i32>, bamp: String) {
     let mut norm_count = vec![];
     for (tid, count) in tidcount.into_iter() {
         let chrom = std::str::from_utf8(head_view.tid2name(tid.try_into().unwrap())).unwrap();
-        if !chrom.contains('_') {
-            let chrom_length = head_view.target_len(tid.try_into().unwrap()).unwrap();
-            chroms.push(chrom);
-            norm_count.push((count as f32) / (chrom_length as f32));
-        }
+        let chrom_length = head_view.target_len(tid.try_into().unwrap()).unwrap();
+        chroms.push(chrom);
+        norm_count.push((count as f32) / (chrom_length as f32));
     }
     let median_count = crate::calculations::median_phaseblocks(norm_count.clone());
     let mut zipped = chroms.iter().zip(norm_count).collect::<Vec<_>>();


### PR DESCRIPTION
Hey,

I've deleted the line! This means any contig name will be accepted. 

I've also move the target override 
```toml
[target.x86_64-apple-darwin]
rustflags = ["-C", "link-arg=-mmacosx-version-min=10.12"]
```

From `Cargo.toml` to `config.toml`. See https://doc.rust-lang.org/cargo/reference/config.html.

This won't make any noticable difference during compilation, but will get rid of the 

```console
warning: unused manifest key: target.x86_64-apple-darwin.rustflags
```

warning during compilation!

Thanks man,
Rory