### PR TITLE
fix: reading from stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,22 +18,22 @@ Or for Rust developers, build cramino with cargo:
 ```text
 cramino [OPTIONS] <INPUT>
 
-ARGS:
-    <INPUT>    cram or bam file to check (or - to read from stdin)
+Arguments:
+  [INPUT]  cram or bam file to check [default: -]
 
-OPTIONS:
-    -t, --threads <THREADS>            Number of parallel decompression threads to use [default: 4]
-    -m, --min-read-len <MIN_READ_LEN>  Minimal length of read to be considered [default: 0]
-    --reference <REFERENCE>            Reference for decompressing cram
-    --hist                             If histograms have to be generated
-    --checksum                         If a checksum has to be calculated
-    --arrow <filename>                 Write data to an arrow format file
-    --karyotype                        Provide normalized number of reads per chromosome
-    --phased                           Calculate metrics for phased reads
-    --spliced                          Calculate metrics for spliced reads
-    --ubam                             Provide metrics for unaligned reads
-    -h, --help                         Print help information
-    -V, --version                      Print version information
+Options:
+  -t, --threads <THREADS>            Number of parallel decompression threads to use [default: 4]
+      --reference <REFERENCE>        reference for decompressing cram
+  -m, --min-read-len <MIN_READ_LEN>  Minimal length of read to be considered [default: 0]
+      --hist                         If histograms have to be generated
+      --checksum                     If a checksum has to be calculated
+      --arrow <ARROW>                Write data to an arrow format file
+      --karyotype                    Provide normalized number of reads per chromosome
+      --phased                       Calculate metrics for phased reads
+      --spliced                      Provide metrics for spliced data
+      --ubam                         Provide metrics for unaligned reads
+  -h, --help                         Print help
+  -V, --version                      Print version
 ```
 
 ## Example output

--- a/src/extract_from_bam.rs
+++ b/src/extract_from_bam.rs
@@ -96,20 +96,23 @@ pub fn extract(args: &crate::Cli) -> (Data, rust_htslib::bam::Header) {
     // sort vectors in descending order (required for N50/N75)
     lengths.sort_unstable_by(|a, b| b.cmp(a));
     identities.sort_unstable_by(|a, b| b.partial_cmp(a).unwrap());
-    (Data {
-        lengths: Some(lengths),
-        all_counts,
-        identities: if !args.ubam { Some(identities) } else { None },
-        tids: if args.karyotype || args.phased {
-            Some(tids)
-        } else {
-            None
+    (
+        Data {
+            lengths: Some(lengths),
+            all_counts,
+            identities: if !args.ubam { Some(identities) } else { None },
+            tids: if args.karyotype || args.phased {
+                Some(tids)
+            } else {
+                None
+            },
+            starts: if args.phased { Some(starts) } else { None },
+            ends: if args.phased { Some(ends) } else { None },
+            phasesets: if args.phased { Some(phasesets) } else { None },
+            exons: if args.spliced { Some(exons) } else { None },
         },
-        starts: if args.phased { Some(starts) } else { None },
-        ends: if args.phased { Some(ends) } else { None },
-        phasesets: if args.phased { Some(phasesets) } else { None },
-        exons: if args.spliced { Some(exons) } else { None },
-    }, header)
+        header,
+    )
 }
 
 /// Calculates the gap-compressed identity

--- a/src/extract_from_bam.rs
+++ b/src/extract_from_bam.rs
@@ -13,7 +13,7 @@ pub struct Data {
     pub exons: Option<Vec<usize>>,
 }
 
-pub fn extract(args: &crate::Cli) -> Data {
+pub fn extract(args: &crate::Cli) -> (Data, rust_htslib::bam::Header) {
     let mut lengths = vec![];
     let mut identities = vec![];
     let mut tids = vec![];
@@ -27,6 +27,8 @@ pub fn extract(args: &crate::Cli) -> Data {
         bam::Reader::from_path(&args.input)
             .expect("Error opening BAM/CRAM file.\nIs the input file correct?\n\n\n\n")
     };
+    let header = bam.header().clone();
+    let header = rust_htslib::bam::Header::from_template(&header);
     bam.set_threads(args.threads)
         .expect("Failure setting decompression threads");
 
@@ -94,7 +96,7 @@ pub fn extract(args: &crate::Cli) -> Data {
     // sort vectors in descending order (required for N50/N75)
     lengths.sort_unstable_by(|a, b| b.cmp(a));
     identities.sort_unstable_by(|a, b| b.partial_cmp(a).unwrap());
-    Data {
+    (Data {
         lengths: Some(lengths),
         all_counts,
         identities: if !args.ubam { Some(identities) } else { None },
@@ -107,7 +109,7 @@ pub fn extract(args: &crate::Cli) -> Data {
         ends: if args.phased { Some(ends) } else { None },
         phasesets: if args.phased { Some(phasesets) } else { None },
         exons: if args.spliced { Some(exons) } else { None },
-    }
+    }, header)
 }
 
 /// Calculates the gap-compressed identity

--- a/src/file_info.rs
+++ b/src/file_info.rs
@@ -23,6 +23,9 @@ impl BamFile {
     }
 
     pub fn file_time(&self) -> String {
+        if self.path == "-" {
+            return "NA".to_string();
+        }
         let metadata = fs::metadata(&self.path);
         if let Ok(time) = metadata.unwrap().created() {
             let datetime: DateTime<Local> = time.into();

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,7 +91,11 @@ fn main() -> Result<(), rust_htslib::errors::Error> {
     Ok(())
 }
 
-fn metrics_from_bam(metrics: Data, args: Cli, header: rust_htslib::bam::Header) -> Result<(), rust_htslib::errors::Error> {
+fn metrics_from_bam(
+    metrics: Data,
+    args: Cli,
+    header: rust_htslib::bam::Header,
+) -> Result<(), rust_htslib::errors::Error> {
     let bam = file_info::BamFile { path: args.input };
     println!("File name\t{}", bam.file_name());
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,6 @@
-pub fn get_genome_size(header: &rust_htslib::bam::Header) -> Result<u64, rust_htslib::errors::Error> {
+pub fn get_genome_size(
+    header: &rust_htslib::bam::Header,
+) -> Result<u64, rust_htslib::errors::Error> {
     let mut genome_size = 0;
     // print header records to the terminal, akin to samtool
     for (key, records) in header.to_hashmap() {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,8 +1,4 @@
-use rust_htslib::{bam, bam::Read};
-
-pub fn get_genome_size(bamp: &String) -> u64 {
-    let bam = bam::Reader::from_path(bamp).unwrap();
-    let header = bam::Header::from_template(bam.header());
+pub fn get_genome_size(header: &rust_htslib::bam::Header) -> Result<u64, rust_htslib::errors::Error> {
     let mut genome_size = 0;
     // print header records to the terminal, akin to samtool
     for (key, records) in header.to_hashmap() {
@@ -14,7 +10,7 @@ pub fn get_genome_size(bamp: &String) -> u64 {
             }
         }
     }
-    genome_size
+    Ok(genome_size)
 }
 
 pub fn accuracy_to_phred(identity: f64) -> usize {


### PR DESCRIPTION
This PR fixes reading a BAM from stdin.

The problem was that there were two parts of the code which read from stdin. So the first read works, but the second read doesn't as stdin has been emptied.

The second place that read from stdin was the function to calculate the genome size, which only needs the header. So I just return a copy of the header from the first read and then made that the input to the `get_genome_size` function.

I've also removed an `unwrap` or two relating to reading the BAM file as unwrapping assumes the BAM will always been `Ok`, which it might not. And the subsequent error would have been cryptic.

I also made `-` the default value for input if no argument is given. This removes the need to add `-` explicitly when calling `cramino`.