### PR TITLE
Option to create read-length scaled histograms

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -62,6 +62,10 @@ pub struct Cli {
     /// Output format (text, json, or tsv)
     #[clap(long, value_parser, default_value_t = OutputFormat::Text)]
     format: OutputFormat,
+
+    /// Scale histogram bins by total basepairs in each bin (not just read count)
+    #[clap(long, value_parser)]
+    pub scaled: bool,
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -108,6 +112,7 @@ fn extract() {
         spliced: false,
         ubam: false,
         format: OutputFormat::Text,
+        scaled: false,
     };
     let (metrics, header) = extract_from_bam::extract(&args);
     assert!(metrics_processor::process_metrics(metrics, &args, header).is_ok())
@@ -129,6 +134,7 @@ fn extract_cram() {
         spliced: false,
         ubam: false,
         format: OutputFormat::Text,
+        scaled: false,
     };
     let (metrics, header) = extract_from_bam::extract(&args);
     assert!(metrics_processor::process_metrics(metrics, &args, header).is_ok())
@@ -148,6 +154,7 @@ fn extract_ubam() {
         spliced: false,
         ubam: true,
         format: OutputFormat::Text,
+        scaled: false,
     };
     let (metrics, header) = extract_from_bam::extract(&args);
     assert!(metrics_processor::process_metrics(metrics, &args, header).is_ok())
@@ -169,6 +176,7 @@ fn extract_url() {
         spliced: false,
         ubam: false,
         format: OutputFormat::Text,
+        scaled: false,
     };
     let (metrics, header) = extract_from_bam::extract(&args);
     assert!(metrics_processor::process_metrics(metrics, &args, header).is_ok())
@@ -188,6 +196,7 @@ fn extract_json() {
         spliced: false,
         ubam: false,
         format: OutputFormat::Json,
+        scaled: false,
     };
     let (metrics, header) = extract_from_bam::extract(&args);
     assert!(metrics_processor::process_metrics(metrics, &args, header).is_ok())
@@ -207,6 +216,7 @@ fn extract_tsv() {
         spliced: false,
         ubam: false,
         format: OutputFormat::Tsv,
+        scaled: false,
     };
     let (metrics, header) = extract_from_bam::extract(&args);
     assert!(metrics_processor::process_metrics(metrics, &args, header).is_ok())
@@ -227,6 +237,7 @@ fn extract_with_high_min_length() {
         spliced: false,
         ubam: false,
         format: OutputFormat::Text,
+        scaled: false,
     };
     
     // The test should still run without panicking
@@ -249,6 +260,7 @@ fn extract_json_with_high_min_length() {
         spliced: false,
         ubam: false,
         format: OutputFormat::Json,
+        scaled: false,
     };
     
     let (metrics, header) = extract_from_bam::extract(&args);
@@ -270,6 +282,7 @@ fn extract_tsv_with_high_min_length() {
         spliced: false,
         ubam: false,
         format: OutputFormat::Tsv,
+        scaled: false,
     };
     
     let (metrics, header) = extract_from_bam::extract(&args);

--- a/src/metrics_processor.rs
+++ b/src/metrics_processor.rs
@@ -264,25 +264,20 @@ pub fn process_metrics(
         OutputFormat::Text => {
             // Print text output using the collected metrics
             crate::text_output::print_text_output(&metrics_obj);
-
             if let Some(hist_file) = &args.hist {
-                histograms::create_histograms(&metrics_data, hist_file, phaseblocks)?;
+                histograms::create_histograms(&metrics_data, hist_file, phaseblocks, args.scaled)?;
             }
         }
         OutputFormat::Json => {
             println!("{}", serde_json::to_string_pretty(&metrics_obj).unwrap());
-            
             if let Some(hist_file) = &args.hist {
-                histograms::create_histograms(&metrics_data, hist_file, phaseblocks)?;
+                histograms::create_histograms(&metrics_data, hist_file, phaseblocks, args.scaled)?;
             }
-        
         }
-
         OutputFormat::Tsv => {
             crate::tsv_output::print_tsv_output(&metrics_obj);
-
             if let Some(hist_file) = &args.hist {
-                histograms::create_histograms(&metrics_data, hist_file, phaseblocks)?;
+                histograms::create_histograms(&metrics_data, hist_file, phaseblocks, args.scaled)?;
             }
         }
     }


### PR DESCRIPTION
Very helpful tool! I sometimes find it more helpful to interpret a histogram where the bars are scaled based on the total number of basepairs in that bin (which is the default method that ONT uses in its plots).

I've set this up as a draft PR for this feature, which can be toggled with `--scaled`. E.g.,:

```
$ cargo run -- --ubam --hist --scaled test-data/small-test-ubam.bam
   Compiling cramino v1.0.3 (/mnt/apps/users/msmith/cramino)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 5.79s
     Running `target/debug/cramino --ubam --hist --scaled test-data/small-test-ubam.bam`
File name       small-test-ubam.bam
Number of alignments    6176
% from total alignments 100.00
Number of reads 6176
Yield [Gb]      0.08
Mean coverage   inf
Yield [Gb] (>25kb)      0.03
N50     21885
N75     12356
Median length   8283.50
Mean length     12426.93

Path    test-data/small-test-ubam.bam
Creation time   NA


# Histogram for read lengths: (scaled by total basepairs)
     0-2000 ∎∎∎∎∎∎
  2000-4000 ∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  4000-6000 ∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  6000-8000 ∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
 8000-10000 ∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
10000-12000 ∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
12000-14000 ∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
14000-16000 ∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
16000-18000 ∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
18000-20000 ∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
20000-22000 ∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
22000-24000 ∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
24000-26000 ∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
26000-28000 ∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
28000-30000 ∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
30000-32000 ∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
32000-34000 ∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
34000-36000 ∎∎∎∎∎∎∎∎∎∎∎∎∎∎
36000-38000 ∎∎∎∎∎∎∎∎∎∎∎∎
38000-40000 ∎∎∎∎∎∎∎∎∎∎∎∎∎
40000-42000 ∎∎∎∎∎∎∎∎∎∎∎
42000-44000 ∎∎∎∎∎∎
44000-46000 ∎∎∎∎∎∎∎∎∎∎
46000-48000 ∎∎∎∎∎∎∎∎
48000-50000 ∎∎∎∎∎∎∎∎
50000-52000 ∎∎∎∎∎∎
52000-54000 ∎∎∎∎
54000-56000 ∎∎∎
56000-58000 ∎∎∎∎∎
58000-60000 ∎∎
     60000+ ∎∎∎∎∎∎∎∎∎∎∎∎
```

I noticed a couple of odd things, for example specifiying `--hist $readfile` causes the program to hang indefinitely, I believe because $readfile is being interpreted as an optional output file for the histogram? Threw me off for a bit when testing `--hist --scaled` vs `--hist`

Leaving this here in case it would be helpful - I'm not overly familiar with rust so probably needs a good look over :)